### PR TITLE
Downloader improvements

### DIFF
--- a/Fridge.xcodeproj/project.pbxproj
+++ b/Fridge.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		C553FBE91DEDC9FA000798D8 /* Downloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		C56923641DF076AD0023DF0E /* DownloadItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadItem.swift; sourceTree = "<group>"; };
 		C56923661DF077CA0023DF0E /* FridgeErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FridgeErrors.swift; sourceTree = "<group>"; };
+		C5D0E6B91DF449A400BA1716 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,12 +46,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		C505E0601DEFAFC700442DDE /* Docs */ = {
+		C505E0601DEFAFC700442DDE /* Helper files */ = {
 			isa = PBXGroup;
 			children = (
+				C5D0E6B91DF449A400BA1716 /* .travis.yml */,
 				C505E0611DEFAFE600442DDE /* README.md */,
 			);
-			name = Docs;
+			name = "Helper files";
 			sourceTree = "<group>";
 		};
 		C553FBD61DEDC540000798D8 = {
@@ -72,7 +74,7 @@
 		C553FBE31DEDC58A000798D8 /* Fridge */ = {
 			isa = PBXGroup;
 			children = (
-				C505E0601DEFAFC700442DDE /* Docs */,
+				C505E0601DEFAFC700442DDE /* Helper files */,
 				C553FBE41DEDC58A000798D8 /* main.swift */,
 				C56923641DF076AD0023DF0E /* DownloadItem.swift */,
 				C56923661DF077CA0023DF0E /* FridgeErrors.swift */,

--- a/Fridge/main.swift
+++ b/Fridge/main.swift
@@ -11,7 +11,8 @@ import Foundation
 
 print("WELCOME TO ❄️FRIDGE❄️")
 
-//initalize shared downloader
+//santa's little helper ;)
+let appTimeout : TimeInterval = TimeInterval(15) //seconds
 
 do {
 //    var item = try DownloadItem(withString: "www.google.com")
@@ -26,23 +27,52 @@ do {
     }
     
     let d = Downloader.shared
+    
+    //setup custom 'caches' directory
+    
+    // SETUP YOUR FINAL DESTINATIONS HERE !!!
+    d.cacheDestination = "/Users/vexy/Desktop/Fridge/"
+    
+    
     d.download(item: item)
     
+    
+    /*
+        Collection of free images that we can use to test Downloader :
+     
+            - http://www.bigfoto.com/airplane.jpg                               #0
+            - http://www.bigfoto.com/image-park-lake.jpg                        #1
+            - http://www.bigfoto.com/dog-animal.jpg                             #2
+            - http://www.bigfoto.com/alps-mythen-image.jpg                      #3
+            - http://www.bigfoto.com/snow-mountains.jpg                         #4
+            - http://www.bigfoto.com/fruits-picture.jpg                         #5
+            - http://www.bigfoto.com/sunset-photo.jpg                           #6
+            - http://www.bigfoto.com/coast.jpg                                  #7
+            - http://www.bigfoto.com/image-leaves.jpg                           #8
+            - http://www.bigfoto.com/sites/main/aegeri-lake-switzerland.JPG     #9
+     
+        Copyright © BigFoto.com
+    */
+    
     ///*
-    let imageFile = try DownloadItem(withString: "http://localhost:8888/images/Red.png")
-    let imageFile2 = try DownloadItem(withString: "http://localhost:8888/images/Blue.png")
-    let imageFile3 = try DownloadItem(withString: "http://localhost:8888/images/Yellow.png")
-    let imageFile4 = try DownloadItem(withString: "http://localhost:8888/images/Violet.png")
-    let imageFile5 = try DownloadItem(withString: "http://localhost:8888/images/Pattern.png")
+    let imageFile0 = try DownloadItem(withString: "http://www.bigfoto.com/airplane.jpg")
+    let imageFile1 = try DownloadItem(withString: "http://www.bigfoto.com/image-park-lake.jpg")
+    let imageFile2 = try DownloadItem(withString: "http://www.bigfoto.com/dog-animal.jpg")
+    let imageFile3 = try DownloadItem(withString: "http://www.bigfoto.com/alps-mythen-image.jpg")
+    let imageFile4 = try DownloadItem(withString: "http://www.bigfoto.com/snow-mountains.jpg")
+    let imageFile5 = try DownloadItem(withString: "http://www.bigfoto.com/fruits-picture.jpg")
+    let imageFile6 = try DownloadItem(withString: "http://www.bigfoto.com/sunset-photo.jpg")
+    let imageFile7 = try DownloadItem(withString: "http://www.bigfoto.com/coast.jpg")
+    let imageFile8 = try DownloadItem(withString: "http://www.bigfoto.com/image-leaves.jpg")
+    let imageFile9 = try DownloadItem(withString: "http://www.bigfoto.com/sites/main/aegeri-lake-switzerland.JPG")
+    
 
-    d.download(items: [imageFile, imageFile2, imageFile3, imageFile4, imageFile5])
+    d.download(items: [imageFile0, imageFile1, imageFile2, imageFile3, imageFile4, imageFile5, imageFile6, imageFile7, imageFile8, imageFile9])
     //*/
     
 } catch {
-    print("Unable to create Download item")
+    print("😔 Unable to create Download item")
 }
 
-//hard stop app after 10 seconds...
-RunLoop.main.run(until: Date(timeIntervalSinceNow: 10))
-
-
+//hard stop this app timeout period
+RunLoop.main.run(until: Date(timeIntervalSinceNow: appTimeout))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ❄️ Fridge ❄️ v0.1b
+# ❄️ Fridge ❄️ v0.55
 [![Build Status](https://travis-ci.org/vexy/Fridge.svg?branch=master)](https://travis-ci.org/vexy/Fridge)
 [![codecov](https://codecov.io/gh/vexy/Fridge/branch/master/graph/badge.svg)](https://codecov.io/gh/vexy/Fridge)
 
@@ -25,9 +25,27 @@ item.onFailure = { (error) in
 //#3: kick-off your download !!
 let d = Downloader.shared
 d.download(item: item)
+
+//small bonus as of v0.55 :
+d.cacheDestination = "/some/folder/that/iwant/"
 ```
 
 
-**STILL UNDER HEAVY DEVELOPMENT**
+## Main features :
+- Easy declaration of file/image/object to be downloaded
+- Asynchronous object download on background threads
+- Assign 'completion' and 'failure' closures to perform your custom work after download
+--  or you can just ignore this and access your object directly after it has been downloaded
+- Customizable destination for downloading objects
+-- you can always use default system provided Caches folder
 
 Stay tunned for more !!
+
+
+---
+If you experience some problems, feel free to fire an issue on 'Issues' page
+
+
+Feel free to contribute at *any time* !!
+
+(**STILL UNDER HEAVY DEVELOPMENT**)


### PR DESCRIPTION
- improved support for multithread access to protected resource
-- introduced serializer that keeps track of download task IDs
- removed unused 'objects' declaration (all download items are now passed directly to 'download' method)
- added ability to set custom destination path after an object has been downloaded
-- needs HEAVY TESTING !!
- small improvements in permaCopy method

BONUS :
- pretyfied comments and method descriptions