### PR TITLE
.travis.yml v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ branches:
 
 before_install:
   - brew update
+  - xcodebuild
 
 script:
 - xcodebuild clean build -project Fridge.xcodeproj -scheme Fridge
-- xcodebuild build test -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY YES
+- xcodebuild test -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY=YES
 
 after_success:
 ##upload coverage data to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c #swift
-osx_image: xcode8.2
+osx_image: xcode8.1
 xcode_project: Fridge.xcodeproj
 xcode_scheme: Fridge
 xcode_sdk: macosx10.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 ##  only:
   - master
   - development
+  - travis_jurney
 
 before_install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: swift #objective-c
+language: objective-c #swift
 osx_image: xcode8.2
 xcode_project: Fridge.xcodeproj
 xcode_scheme: Fridge
@@ -16,7 +16,7 @@ before_install:
 
 script:
 - xcodebuild clean build -project Fridge.xcodeproj -scheme Fridge
-- xcodebuild build test -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY=YES
+- xcodebuild build test -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY YES
 
 after_success:
 ##upload coverage data to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,27 @@
-language: objective-c
-osx_image: xcode8
+language: swift #objective-c
+osx_image: xcode8.2
 xcode_project: Fridge.xcodeproj
 xcode_scheme: Fridge
 xcode_sdk: macosx10.12
 
-# safelist
+# put back to only: - master later
 branches:
-  only:
+##  only:
   - master
+  - development
+
+before_install:
+  - brew update
 
 script:
 - xcodebuild clean build -project Fridge.xcodeproj -scheme Fridge
-- xcodebuild -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY=YES build test
-
-# Following breaks build : - xcodebuild test -project Fridge.xcodeproj -scheme FridgeItemTest
+- xcodebuild build test -project Fridge.xcodeproj -scheme Fridge -sdk macosx -configuration Debug -enableCodeCoverage YES ENABLE_TESTABILITY=YES
 
 after_success:
-## we're trying to Test if build passes
+##upload coverage data to codecov
+- bash <(curl -s https://codecov.io/bash)
+
+after_failure:
+## check what's available and how
 - xcodebuild -project Fridge.xcodeproj -scheme Fridge -list
 - xcodebuild -project Fridge.xcodeproj -scheme Fridge -showBuildSettings
-- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Radical change to `.travis.yml` for further inspection of possible solution

- ~Switching `language` to : `swift`   (*should be put back to objective-c if doesn't work*)~
  - this doens't work as of this build [Travis-#39](https://travis-ci.org/vexy/Fridge/builds/186114967)
- Changed `xcode8` to ~`xcode2`~ (*fails -> trying with xcode8.1*)  ref : 81b1a66
- travis-ci will now build **all* branches, including this one 
- Updates to `before_update:` statement :
  - homebrew updates it's libraries
  - xcodebuild dump for sanity check (**use to compare travis-ci build outputs**)
- Splitting `success`/`failure` blocks
  - success will perform codecov tasks
  - failure will dump system settings (through `xcodebuild -list`)